### PR TITLE
Remove py27 from build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,6 @@ env:
     - TOXENV=docs
 matrix:
   include:
-    - python: '2.7'
-      env:
-        - TOXENV=py27,report,codecov
     # - python: '3.3'
     #   env:
     #     - TOXENV=py33,report,codecov

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,21 +7,10 @@ environment:
     WITH_COMPILER: 'cmd /E:ON /V:ON /C .\ci\appveyor-with-compiler.cmd'
   matrix:
     - TOXENV: check
-      TOXPYTHON: C:\Python27\python.exe
-      PYTHON_HOME: C:\Python27
-      PYTHON_VERSION: '2.7'
+      TOXPYTHON: C:\Python34\python.exe
+      PYTHON_HOME: C:\Python34
+      PYTHON_VERSION: '3.4'
       PYTHON_ARCH: '32'
-    - TOXENV: 'py27,report,codecov'
-      TOXPYTHON: C:\Python27\python.exe
-      PYTHON_HOME: C:\Python27
-      PYTHON_VERSION: '2.7'
-      PYTHON_ARCH: '32'
-    - TOXENV: 'py27,report,codecov'
-      TOXPYTHON: C:\Python27-x64\python.exe
-      WINDOWS_SDK_VERSION: v7.0
-      PYTHON_HOME: C:\Python27-x64
-      PYTHON_VERSION: '2.7'
-      PYTHON_ARCH: '64'
     - TOXENV: 'py33,report,codecov'
       TOXPYTHON: C:\Python33\python.exe
       PYTHON_HOME: C:\Python33

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,6 @@ setup(
         'Operating System :: POSIX',
         'Operating System :: Microsoft :: Windows',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         # 'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',

--- a/tox.ini
+++ b/tox.ini
@@ -4,14 +4,14 @@
 envlist =
     clean,
     check,
-    {py27,py33,py34,py35,py36,pypy},
+    {py33,py34,py35,py36,pypy},
     report,
     docs
 
 [testenv]
 basepython =
     pypy: {env:TOXPYTHON:pypy}
-    {py27,docs,spell}: {env:TOXPYTHON:python2.7}
+    {py34,docs,spell}: {env:TOXPYTHON:python3.4}
     py33: {env:TOXPYTHON:python3.3}
     py34: {env:TOXPYTHON:python3.4}
     py35: {env:TOXPYTHON:python3.5}
@@ -98,4 +98,3 @@ commands =
 commands = coverage erase
 skip_install = true
 deps = coverage
-


### PR DESCRIPTION
In anticipation of Python2.7 EOL, this patch set removes reference and build
for python 2.7.  The default should be using py34 instead.

Closes: #4

Signed-off-by: Tin Lam <tin@irrational.io>