### PR TITLE
Add tests for growlog.main methods Fixes #5

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,7 +1,18 @@
+import sys
 import unittest
 
 from growlog.main import Crop
+from growlog.main import add_to_growlog
+from growlog.main import create_growlog
+from growlog.main import delete_crop_from_growlog
 from growlog.main import load_growlog
+from growlog.main import save_growlog
+from growlog.main import update_crop_in_growlog
+
+try:
+    from unittest.mock import patch, mock_open
+except ImportError:
+    from mock import patch, mock_open  # py27
 
 
 class TestCrop(unittest.TestCase):
@@ -25,10 +36,78 @@ class TestCrop(unittest.TestCase):
 
 
 class TestLoader(unittest.TestCase):
+    def setUp(self):
+        if sys.version_info.major <= 2:
+            self.builtin_name = "__builtin__.open"
+        else:
+            self.builtin_name = "builtins.open"
 
     def test_load_growlog(self):
-        g = load_growlog()
-        self.assertEquals(type([]), type(g))
-        # name = 'Eggplant'
-        # date = '05-30-2018'
-        # self.assertEquals(type(Crop(name, date)), type(g[0]))
+        mocked_content = """
+        - environment: indoor
+          harvest_date: null
+          name: 'Cannabis'
+          notes: Good for migraine
+          qty: 420
+          start_date: 2018
+        """
+        with patch(self.builtin_name, mock_open(read_data=mocked_content)) as mock_file:
+            g = load_growlog()
+            self.assertEqual(g[0].environment, 'indoor')
+            mock_file.assert_called_with('./growlog.yml', 'r')
+
+    def test_save_growlog(self):
+        mock_file = mock_open()
+        crop_list = [Crop(name="Cannabis", qty=420, notes="Good for depression")]
+
+        with patch(self.builtin_name, mock_file, create=True):
+            save_growlog(crop_list)
+        mock_file.assert_called_with('./growlog.yml', 'w')
+        # handle = mock_file()
+        # handle.write.assert_called_once_with(mocked_data)
+
+    @patch('growlog.main.load_growlog', lambda *x: [])
+    @patch('growlog.main.save_growlog')
+    def test_add_to_growlog(self, save_mock=None):
+        crop_data = dict(name="Cannabis", qty=420, notes="Great for eating disorders")
+        add_to_growlog(crop_data)
+        save_mock.assert_called_once_with([{
+            'environment': 'outdoor',
+            'name': 'Cannabis',
+            'qty': 420,
+            'start_date': '2018',
+            'harvest_date': None,
+            'notes': 'Great for eating disorders'
+        }])
+
+    def test_create_growlog(self):
+        self.assertEqual(create_growlog(), [])
+
+    @patch('growlog.main.save_growlog')
+    @patch('growlog.main.load_growlog')
+    def test_update_crop_in_growlog(self, load_mock=None, save_mock=None):
+        load_mock.return_value = [
+            Crop(name="Cannabis", qty=420, notes="Good to grow")
+        ]
+        update_crop_in_growlog(name="Cannabis", key="notes", val="Good to dry")
+
+        save_mock.assert_called_once_with([{
+            'environment': 'outdoor',
+            'name': 'Cannabis',
+            'qty': 420,
+            'start_date': '2018',
+            'harvest_date': None,
+            'notes': 'Good to dry'
+        }])
+        load_mock.assert_called_once_with = ()
+
+    @patch('growlog.main.save_growlog')
+    @patch('growlog.main.load_growlog')
+    def test_delete_crop_from_growlog(self, load_mock=None, save_mock=None):
+        load_mock.return_value = [
+            Crop(name="Cannabis", qty=420, notes="Good to sell and delete")
+        ]
+        delete_crop_from_growlog(name="Cannabis")
+
+        save_mock.assert_called_once_with([])
+        load_mock.assert_called_once_with = ()

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,7 @@ passenv =
     *
 usedevelop = false
 deps =
+    mock
     pytest
     pytest-travis-fold
     pytest-cov


### PR DESCRIPTION
Hi @accraze 
Here is a PR for tests on `growlog.main`. Let me know what you think? 
:seedling: :herb: :deciduous_tree: