### PR TITLE
Fix CI Build

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -82,7 +82,6 @@ deps =
     codecov
 skip_install = true
 commands =
-    coverage xml --ignore-errors
     codecov []
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -90,7 +90,6 @@ commands =
 deps = coverage
 skip_install = true
 commands =
-    coverage combine --append
     coverage report
     coverage html
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ envlist =
 [testenv]
 basepython =
     pypy: {env:TOXPYTHON:pypy}
-    {py34,docs,spell}: {env:TOXPYTHON:python3.4}
+    {docs,spell}: {env:TOXPYTHON:python3.4}
     py33: {env:TOXPYTHON:python3.3}
     py34: {env:TOXPYTHON:python3.4}
     py35: {env:TOXPYTHON:python3.5}


### PR DESCRIPTION
Removes coverage `append` and `xml` calls.
Also removes an additional reference to `py34`

resolves #9 